### PR TITLE
Fix admin class typo

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -4,12 +4,12 @@ from blog.models import Category, Post, Comment
 class CategoryAdmin(admin.ModelAdmin):
     pass
 
-class PostAdmion(admin.ModelAdmin):
+class PostAdmin(admin.ModelAdmin):
     pass
 
 class CommentAdmin(admin.ModelAdmin):
     pass
 
 admin.site.register(Category, CategoryAdmin)
-admin.site.register(Post, PostAdmion)
+admin.site.register(Post, PostAdmin)
 admin.site.register(Comment, CommentAdmin)


### PR DESCRIPTION
## Summary
- correct typo in blog admin class name

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68559ee476e08323b7ef12fef46730d9